### PR TITLE
Feat sincronizar tiempo de reproducción entre todxs lxs participantes 

### DIFF
--- a/assets/js/hooks/player-syncing.js
+++ b/assets/js/hooks/player-syncing.js
@@ -127,6 +127,11 @@ const PlayerSyncing = initPlayer => ({
       )
       !shouldPlay && player.pauseVideo()
     })
+
+    setInterval(() => {
+      const currentTime = player.getCurrentTime()
+      this.pushEvent('receive_current_video_time', currentTime)
+    }, 500)
   }
 })
 

--- a/lib/dj_rumble/rooms/room.ex
+++ b/lib/dj_rumble/rooms/room.ex
@@ -23,7 +23,7 @@ defmodule DjRumble.Rooms.Room do
   def changeset(room, attrs) do
     room
     |> cast(attrs, @fields)
-    |> validate_required(@fields)
+    |> validate_required([:name, :slug])
     |> format_slug()
     |> unique_constraint(:slug)
   end

--- a/lib/dj_rumble/rooms/room.ex
+++ b/lib/dj_rumble/rooms/room.ex
@@ -8,6 +8,7 @@ defmodule DjRumble.Rooms.Room do
   schema "rooms" do
     field :name, :string
     field :slug, :string
+    field :video_tracker, :string, default: ""
 
     many_to_many :videos, DjRumble.Rooms.Video, join_through: "rooms_videos"
 
@@ -16,7 +17,7 @@ defmodule DjRumble.Rooms.Room do
     timestamps()
   end
 
-  @fields [:name, :slug]
+  @fields [:name, :slug, :video_tracker]
 
   @doc false
   def changeset(room, attrs) do

--- a/lib/dj_rumble_web/live/components/navbar/navbar.ex
+++ b/lib/dj_rumble_web/live/components/navbar/navbar.ex
@@ -1,0 +1,65 @@
+defmodule DjRumbleWeb.Live.Components.Navbar do
+  @moduledoc """
+  Responsible for displaying navbar controls
+  """
+
+  use DjRumbleWeb, :live_component
+
+  def update(assigns, socket) do
+    {:ok,
+     socket
+     |> assign(assigns)}
+  end
+
+  def render(assigns) do
+    ~L"""
+      <div class="flex flex-row-reverse text-gray-300">
+        <%= render_navbar(assigns.visitor, assigns.username, assigns.homepage, @socket) %>
+      </div>
+    """
+  end
+
+  defp render_navbar(true, username, homepage, assigns) do
+    ~L"""
+      <%= render_item(%{to: Routes.user_registration_path(assigns, :new), method: nil, text: "Sign up"}, assigns) %>
+      <%= render_item(%{to: Routes.user_session_path(assigns, :new), method: nil, text: "Sign in"}, assigns) %>
+      <%= if homepage do %>
+        <%= render_item(%{to: Routes.room_index_path(assigns, :index), method: nil, text: "Home"}, assigns) %>
+      <% end %>
+      <%= render_username(username, assigns) %>
+    """
+  end
+
+  defp render_navbar(false, username, homepage, assigns) do
+    ~L"""
+      <%= render_item(%{to: Routes.user_session_path(assigns, :delete), method: :delete, text: "Log out"}, assigns) %>
+      <%= render_item(%{to: Routes.user_settings_path(assigns, :index), method: nil, text: "Settings"}, assigns) %>
+      <%= if homepage do %>
+        <%= render_item(%{to: Routes.room_index_path(assigns, :index), method: nil, text: "Home"}, assigns) %>
+      <% end %>
+      <%= render_username(username, assigns) %>
+    """
+  end
+
+  defp render_username(username, assigns) do
+    ~L"""
+      <div class="m-2">
+        <p>
+          Hello, <span class="text-green-300"><%= username %></span>
+        </p>
+      </div>
+    """
+  end
+
+  defp render_item(%{to: to, method: method, text: text}, assigns) do
+    ~L"""
+      <div class="m-2">
+        <%= link to: to, method: method,
+          class: "text-gray-300 hover:text-green-300 transition duration-500 ease-in-out"
+        do %>
+          <%= text %>
+        <% end %>
+      </div>
+    """
+  end
+end

--- a/lib/dj_rumble_web/live/room_live/index.html.leex
+++ b/lib/dj_rumble_web/live/room_live/index.html.leex
@@ -1,36 +1,8 @@
-<div class="flex flex-row-reverse text-gray-300 hover:text-green-300">
-  <%= if !@visitor do %>
-    <div class="m-2">
-      <%= link to: Routes.user_session_path(@socket, :delete), method: :delete,
-        class: "text-gray-300 hover:text-green-300 transition duration-500 ease-in-out"
-      do %>
-        Log out
-      <% end %>
-    </div>
-    <div class="m-2">
-      <%= link to: Routes.user_settings_path(@socket, :index),
-        class: "text-gray-300 hover:text-green-300 transition duration-500 ease-in-out"
-      do %>
-        Settings
-      <% end %>
-    </div>
-  <% else %>
-    <div class="m-2">
-      <%= link to: Routes.user_registration_path(@socket, :new),
-        class: "text-gray-300 hover:text-green-300 transition duration-500 ease-in-out"
-      do %>
-        Sign up
-      <% end %>
-    </div>
-    <div class="m-2">
-      <%= link to: Routes.user_session_path(@socket, :new),
-        class: "text-gray-300 hover:text-green-300 transition duration-500 ease-in-out"
-      do %>
-        Sign in
-      <% end %>
-    </div>
-  <% end %>
-</div>
+<%= live_component @socket, DjRumbleWeb.Live.Components.Navbar,
+  visitor: @visitor,
+  username: @user.username,
+  homepage: false
+%>
 
 <h3 class="text-gray-50 p-4 m-4">Dj Rooms</h3>
 
@@ -44,15 +16,15 @@
 <% end %>
 
 <div
-  class="rooms-container new-live-rooms-list text-gray-50"
+  class="rooms-container text-gray-50"
 >
   <%= if @rooms != [] do %>
 
   <div class="mb-4">
     <ul class="like-list grid gap-2 grid-cols-1 lg:grid-cols-2 m-2">
     <%= for room <- @rooms do %>
-      <li class="room-item col-span-1 hover-card px-2 cursor-pointer">
-        <div class="flex grid grid-cols-8 xl:grid-cols-12">
+      <li class="room-item col-span-1 hover:text-green-300 px-2 cursor-pointer round">
+        <div class="flex grid grid-cols-8 xl:grid-cols-12 shadow-card">
 
           <div class="
             col-span-2 row-span-1

--- a/lib/dj_rumble_web/live/room_live/show.ex
+++ b/lib/dj_rumble_web/live/room_live/show.ex
@@ -44,12 +44,12 @@ defmodule DjRumbleWeb.RoomLive.Show do
         )
 
         {:ok,
-          socket
-          |> assign(:videos, room.videos)
-          |> assign_tracker(room)
-          |> assign(:index_playing, index_playing)
-          |> assign(:connected_users, connected_users)
-          |> assign(:current_video_time, 0)}
+         socket
+         |> assign(:videos, room.videos)
+         |> assign_tracker(room)
+         |> assign(:index_playing, index_playing)
+         |> assign(:connected_users, connected_users)
+         |> assign(:current_video_time, 0)}
     end
   end
 
@@ -66,6 +66,7 @@ defmodule DjRumbleWeb.RoomLive.Show do
     case presence do
       [] ->
         %{videos: videos} = socket.assigns
+
         case Enum.at(videos, 0) do
           nil ->
             {:noreply, socket}
@@ -80,6 +81,7 @@ defmodule DjRumbleWeb.RoomLive.Show do
                time: 0
              })}
         end
+
       _ps ->
         Phoenix.PubSub.subscribe(DjRumble.PubSub, "room:" <> slug <> ":request_initial_state")
         # Tells every node the requester node needs an initial state
@@ -121,6 +123,7 @@ defmodule DjRumbleWeb.RoomLive.Show do
   @impl true
   def handle_event("receive_current_video_time", current_time, socket) do
     %{room: room} = socket.assigns
+
     case socket.id == room.video_tracker do
       true ->
         Phoenix.PubSub.broadcast(
@@ -137,7 +140,8 @@ defmodule DjRumbleWeb.RoomLive.Show do
   end
 
   def handle_info({:request_initial_state, _params}, socket) do
-    %{videos: videos, index_playing: index_playing, current_video_time: current_video_time} = socket.assigns
+    %{videos: videos, index_playing: index_playing, current_video_time: current_video_time} =
+      socket.assigns
 
     :ok =
       Phoenix.PubSub.broadcast_from(
@@ -158,7 +162,9 @@ defmodule DjRumbleWeb.RoomLive.Show do
   def handle_info({:receive_initial_state, params}, socket) do
     %{room: %{slug: slug}} = socket.assigns
     Phoenix.PubSub.unsubscribe(DjRumble.PubSub, "room:" <> slug <> ":request_initial_state")
-    %{videos: videos, index_playing: index_playing, current_video_time: current_video_time} = params
+
+    %{videos: videos, index_playing: index_playing, current_video_time: current_video_time} =
+      params
 
     socket =
       socket
@@ -172,9 +178,14 @@ defmodule DjRumbleWeb.RoomLive.Show do
 
       _xs ->
         %{video_id: video_id} = Enum.at(videos, index_playing)
+
         {:noreply,
          socket
-         |> push_event("receive_player_state", %{shouldPlay: true, time: current_video_time, videoId: video_id})}
+         |> push_event("receive_player_state", %{
+           shouldPlay: true,
+           time: current_video_time,
+           videoId: video_id
+         })}
     end
   end
 
@@ -195,8 +206,8 @@ defmodule DjRumbleWeb.RoomLive.Show do
     case is_my_presence(socket.id, payload) do
       false ->
         {:noreply,
-          socket
-          |> push_event("presence-changed", %{})}
+         socket
+         |> push_event("presence-changed", %{})}
 
       true ->
         {:noreply, socket}
@@ -205,8 +216,8 @@ defmodule DjRumbleWeb.RoomLive.Show do
 
   def handle_info({:receive_current_video_time, %{time: time}}, socket) do
     {:noreply,
-      socket
-      |> assign(:current_video_time, time)}
+     socket
+     |> assign(:current_video_time, time)}
   end
 
   defp page_title(:show), do: "Show Room"
@@ -231,6 +242,7 @@ defmodule DjRumbleWeb.RoomLive.Show do
     case list_filtered_present(room.slug, current_user) do
       [] ->
         {:ok, updated_room} = Rooms.update_room(room, %{video_tracker: current_user})
+
         socket
         |> assign(:room, updated_room)
 

--- a/lib/dj_rumble_web/live/room_live/show.ex
+++ b/lib/dj_rumble_web/live/room_live/show.ex
@@ -33,7 +33,7 @@ defmodule DjRumbleWeb.RoomLive.Show do
         connected_users = get_list_from_slug(slug)
 
         # Subscribe to the topic
-        DjRumbleWeb.Endpoint.subscribe(topic)
+        Phoenix.PubSub.subscribe(DjRumble.PubSub, topic)
 
         # Track changes to the topic
         Presence.track(
@@ -44,11 +44,12 @@ defmodule DjRumbleWeb.RoomLive.Show do
         )
 
         {:ok,
-         socket
-         |> assign(:room, room)
-         |> assign(:videos, room.videos)
-         |> assign(:index_playing, index_playing)
-         |> assign(:connected_users, connected_users)}
+          socket
+          |> assign(:videos, room.videos)
+          |> assign_tracker(room)
+          |> assign(:index_playing, index_playing)
+          |> assign(:connected_users, connected_users)
+          |> assign(:current_video_time, 0)}
     end
   end
 
@@ -59,19 +60,38 @@ defmodule DjRumbleWeb.RoomLive.Show do
 
   @impl true
   def handle_event("player_is_ready", _params, socket) do
-    case Enum.at(socket.assigns.videos, 0) do
-      nil ->
-        {:noreply, socket}
+    %{room: %{slug: slug}} = socket.assigns
+    presence = list_filtered_present(slug, socket.id)
 
-      video ->
-        {:noreply,
-         socket
-         |> assign(:page_title, page_title(video))
-         |> push_event("receive_player_state", %{
-           videoId: video.video_id,
-           shouldPlay: true,
-           time: 0
-         })}
+    case presence do
+      [] ->
+        %{videos: videos} = socket.assigns
+        case Enum.at(videos, 0) do
+          nil ->
+            {:noreply, socket}
+
+          video ->
+            {:noreply,
+             socket
+             |> assign(:page_title, page_title(video))
+             |> push_event("receive_player_state", %{
+               videoId: video.video_id,
+               shouldPlay: true,
+               time: 0
+             })}
+        end
+      _ps ->
+        Phoenix.PubSub.subscribe(DjRumble.PubSub, "room:" <> slug <> ":request_initial_state")
+        # Tells every node the requester node needs an initial state
+        :ok =
+          Phoenix.PubSub.broadcast_from(
+            DjRumble.PubSub,
+            self(),
+            "room:" <> socket.assigns.room.slug,
+            {:request_initial_state, %{}}
+          )
+
+        {:noreply, socket}
     end
   end
 
@@ -99,13 +119,94 @@ defmodule DjRumbleWeb.RoomLive.Show do
   end
 
   @impl true
+  def handle_event("receive_current_video_time", current_time, socket) do
+    %{room: room} = socket.assigns
+    case socket.id == room.video_tracker do
+      true ->
+        Phoenix.PubSub.broadcast(
+          DjRumble.PubSub,
+          "room:" <> room.slug,
+          {:receive_current_video_time, %{time: current_time}}
+        )
+
+        {:noreply, socket}
+
+      false ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_info({:request_initial_state, _params}, socket) do
+    %{videos: videos, index_playing: index_playing, current_video_time: current_video_time} = socket.assigns
+
+    :ok =
+      Phoenix.PubSub.broadcast_from(
+        DjRumble.PubSub,
+        self(),
+        "room:" <> socket.assigns.room.slug <> ":request_initial_state",
+        {:receive_initial_state,
+         %{
+           videos: videos,
+           index_playing: index_playing,
+           current_video_time: current_video_time
+         }}
+      )
+
+    {:noreply, socket}
+  end
+
+  def handle_info({:receive_initial_state, params}, socket) do
+    %{room: %{slug: slug}} = socket.assigns
+    Phoenix.PubSub.unsubscribe(DjRumble.PubSub, "room:" <> slug <> ":request_initial_state")
+    %{videos: videos, index_playing: index_playing, current_video_time: current_video_time} = params
+
+    socket =
+      socket
+      |> assign(:videos, videos)
+      |> assign(:index_playing, index_playing)
+      |> assign(:current_video_time, current_video_time)
+
+    case videos do
+      [] ->
+        {:noreply, socket}
+
+      _xs ->
+        %{video_id: video_id} = Enum.at(videos, index_playing)
+        {:noreply,
+         socket
+         |> push_event("receive_player_state", %{shouldPlay: true, time: current_video_time, videoId: video_id})}
+    end
+  end
+
+  @impl true
   def handle_info(
-        %{event: "presence_diff", payload: %{joins: _joins, leaves: _leaves}},
+        %{event: "presence_diff", payload: payload},
         %{assigns: %{room: %{slug: slug}}} = socket
       ) do
     connected_users = get_list_from_slug(slug)
 
-    {:noreply, assign(socket, :connected_users, connected_users)}
+    room = handle_video_tracker_activity(slug, connected_users, payload)
+
+    socket =
+      socket
+      |> assign(:connected_users, connected_users)
+      |> assign(:room, room)
+
+    case is_my_presence(socket.id, payload) do
+      false ->
+        {:noreply,
+          socket
+          |> push_event("presence-changed", %{})}
+
+      true ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_info({:receive_current_video_time, %{time: time}}, socket) do
+    {:noreply,
+      socket
+      |> assign(:current_video_time, time)}
   end
 
   defp page_title(:show), do: "Show Room"
@@ -116,5 +217,52 @@ defmodule DjRumbleWeb.RoomLive.Show do
       nil -> ""
       _ -> video.title
     end
+  end
+
+  defp list_filtered_present(slug, uuid) do
+    Presence.list("room:" <> slug)
+    |> Enum.filter(fn {k, _} -> k !== uuid end)
+    |> Enum.map(fn {k, _} -> k end)
+  end
+
+  defp assign_tracker(socket, room) do
+    current_user = socket.id
+
+    case list_filtered_present(room.slug, current_user) do
+      [] ->
+        {:ok, updated_room} = Rooms.update_room(room, %{video_tracker: current_user})
+        socket
+        |> assign(:room, updated_room)
+
+      _xs ->
+        socket
+        |> assign(:room, room)
+    end
+  end
+
+  defp handle_video_tracker_activity(slug, presence, %{leaves: leaves}) do
+    room = Rooms.get_room_by_slug(slug)
+    video_tracker = room.video_tracker
+
+    case video_tracker in Map.keys(leaves) do
+      false ->
+        room
+
+      true ->
+        case presence do
+          [] ->
+            {:ok, updated_room} = Rooms.update_room(room, %{video_tracker: ""})
+            updated_room
+
+          [p | _ps] ->
+            {:ok, updated_room} = Rooms.update_room(room, %{video_tracker: p.uuid})
+            updated_room
+        end
+    end
+  end
+
+  defp is_my_presence(id, presence_payload) do
+    Enum.any?(Map.to_list(presence_payload.joins), fn {x, _} -> x == id end) ||
+      Enum.any?(Map.to_list(presence_payload.leaves), fn {x, _} -> x == id end)
   end
 end

--- a/lib/dj_rumble_web/live/room_live/show.html.leex
+++ b/lib/dj_rumble_web/live/room_live/show.html.leex
@@ -1,11 +1,8 @@
-<%= if @live_action in [:edit] do %>
-  <%= live_modal @socket, DjRumbleWeb.RoomLive.FormComponent,
-    id: @room.id,
-    title: @page_title,
-    action: @live_action,
-    room: @room,
-    return_to: Routes.room_show_path(@socket, :show, @room) %>
-<% end %>
+<%= live_component @socket, DjRumbleWeb.Live.Components.Navbar,
+  visitor: @visitor,
+  username: @user.username,
+  homepage: true
+%>
 
 <div class="grid grid-cols-6 gap-4">
   <div class="rounded-lg bg-black col-start-2 col-span-4 text-center p-4">

--- a/priv/repo/migrations/20210513005434_create_room_video_tracker.exs
+++ b/priv/repo/migrations/20210513005434_create_room_video_tracker.exs
@@ -1,0 +1,9 @@
+defmodule DjRumble.Repo.Migrations.CreateRoomVideoTracker do
+  use Ecto.Migration
+
+  def change do
+    alter table(:rooms) do
+      add :video_tracker, :string, default: ""
+    end
+  end
+end


### PR DESCRIPTION
Este PR provee:

+ Mecanismo simple de sincronización de tiempos de video

La solución es rudimentaria y propone la persistencia de un peer que actúa como tracker del tiempo. Si el peer se descoencta, el próximo peer conectado será quien provea el tiempo actual de video.

Esta es una solución parcial al problema de contar con un mecanismo centralizado y aislado del controlador de la vista que permita persistir en memoria y servir el tiempo actual del video de una sala.