### PR TITLE
Restringir que lxs usuarixs puedan votar solo una vez

### DIFF
--- a/lib/dj_rumble/rooms/matchmaking.ex
+++ b/lib/dj_rumble/rooms/matchmaking.ex
@@ -136,6 +136,8 @@ defmodule DjRumble.Rooms.Matchmaking do
         {_ref, {round_pid, video, _time, user}} = state.current_round
         Logger.info(fn -> "Sending current round details." end)
 
+        :ok = RoundServer.on_player_join(round_pid)
+
         round = RoundServer.get_round(round_pid)
 
         :ok = send_playback_details(pid, round, video, user)

--- a/lib/dj_rumble/rooms/matchmaking.ex
+++ b/lib/dj_rumble/rooms/matchmaking.ex
@@ -43,8 +43,8 @@ defmodule DjRumble.Rooms.Matchmaking do
     GenServer.call(server, :get_current_round)
   end
 
-  def score(server, type) do
-    GenServer.call(server, {:score, type})
+  def score(server, user, type) do
+    GenServer.call(server, {:score, user, type})
   end
 
   def initial_state(args) do
@@ -145,7 +145,7 @@ defmodule DjRumble.Rooms.Matchmaking do
   end
 
   @impl GenServer
-  def handle_call({:score, type}, _from, state) do
+  def handle_call({:score, user, type}, _from, state) do
     {_ref, {round_pid, _video, _time, _user}} = state.current_round
 
     response =

--- a/lib/dj_rumble/rooms/matchmaking.ex
+++ b/lib/dj_rumble/rooms/matchmaking.ex
@@ -151,7 +151,7 @@ defmodule DjRumble.Rooms.Matchmaking do
     response =
       case Process.alive?(round_pid) do
         true ->
-          %Round.InProgress{} = RoundServer.score(round_pid, type)
+          %Round.InProgress{} = RoundServer.score(round_pid, user, type)
 
         false ->
           :error

--- a/lib/dj_rumble/rooms/matchmaking.ex
+++ b/lib/dj_rumble/rooms/matchmaking.ex
@@ -309,7 +309,7 @@ defmodule DjRumble.Rooms.Matchmaking do
 
   defp schedule_round(video, room, user) do
     %{slug: slug} = room
-    {:ok, pid} = RoundSupervisor.start_round_server(RoundSupervisor, {slug, 0})
+    {:ok, pid} = RoundSupervisor.start_round_server(RoundSupervisor, {slug})
     ref = Process.monitor(pid)
 
     :ok = Channels.broadcast(:room, slug, {:round_scheduled, RoundServer.get_round(pid)})

--- a/lib/dj_rumble/rooms/room_server.ex
+++ b/lib/dj_rumble/rooms/room_server.ex
@@ -89,12 +89,12 @@ defmodule DjRumble.Rooms.RoomServer do
   end
 
   @impl GenServer
-  def handle_call({:score, _user, type}, _from, state) do
+  def handle_call({:score, user, type}, _from, state) do
     %{matchmaking_server: matchmaking_server} = state
 
-    case Matchmaking.score(matchmaking_server, type) do
+    case Matchmaking.score(matchmaking_server, user, type) do
       :error ->
-        {:noreply, state}
+        {:reply, :ok, state}
 
       round ->
         :ok =

--- a/lib/dj_rumble/rounds/round_server.ex
+++ b/lib/dj_rumble/rounds/round_server.ex
@@ -40,7 +40,7 @@ defmodule DjRumble.Rounds.RoundServer do
     GenServer.call(pid, {:set_round_time, time})
   end
 
-  def score(pid, type) do
+  def score(pid, _user, type) do
     GenServer.call(pid, {:score, type})
   end
 

--- a/lib/dj_rumble/rounds/round_server.ex
+++ b/lib/dj_rumble/rounds/round_server.ex
@@ -36,8 +36,8 @@ defmodule DjRumble.Rounds.RoundServer do
     GenServer.call(pid, {:set_round_time, time})
   end
 
-  def score(pid, _user, type) do
-    GenServer.call(pid, {:score, type})
+  def score(pid, user, type) do
+    GenServer.call(pid, {:score, user, type})
   end
 
   def initial_state(args) do
@@ -89,7 +89,7 @@ defmodule DjRumble.Rounds.RoundServer do
   end
 
   @impl GenServer
-  def handle_call({:score, type}, _from, %{round: %Round.InProgress{} = round} = state) do
+  def handle_call({:score, _user, type}, _from, %{round: %Round.InProgress{} = round} = state) do
     round = Round.set_score(round, type)
     {:reply, round, %{state | round: round}}
   end

--- a/lib/dj_rumble/rounds/round_supervisor.ex
+++ b/lib/dj_rumble/rounds/round_supervisor.ex
@@ -10,8 +10,8 @@ defmodule DjRumble.Rounds.RoundSupervisor do
     DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
   end
 
-  def start_round_server(supervisor, {room_slug, round_time}) do
-    DynamicSupervisor.start_child(supervisor, {RoundServer, {room_slug, round_time}})
+  def start_round_server(supervisor, {room_slug}) do
+    DynamicSupervisor.start_child(supervisor, {RoundServer, {room_slug}})
   end
 
   def list_round_servers(supervisor \\ __MODULE__) do

--- a/lib/dj_rumble_web/channels/channels.ex
+++ b/lib/dj_rumble_web/channels/channels.ex
@@ -7,6 +7,7 @@ defmodule DjRumbleWeb.Channels do
   @player_is_ready_topic "room:<slug>:ready"
   @matchmaking_details_request_topic "matchmaking:<slug>:waiting_for_details"
   @initial_chat_request_topic "room:<slug>:request_initial_chat"
+  @score_topic "room:<slug>:score"
 
   def get_topic(:room), do: @room_topic
 
@@ -15,6 +16,8 @@ defmodule DjRumbleWeb.Channels do
   def get_topic(:matchmaking_details_request), do: @matchmaking_details_request_topic
 
   def get_topic(:initial_chat_request), do: @initial_chat_request_topic
+
+  def get_topic(:score), do: @score_topic
 
   def get_topic(type, slug), do: String.replace(get_topic(type), "<slug>", slug)
 

--- a/lib/dj_rumble_web/live/components/player_controls/player_controls.html.leex
+++ b/lib/dj_rumble_web/live/components/player_controls/player_controls.html.leex
@@ -3,9 +3,9 @@
 
     <%= live_component DjRumbleWeb.Live.Components.PlayerControls.ScorePanel,
       id: "dj-rumble-score-panel",
+      live_score: @live_score,
       room_server: @room_server,
       scoring_enabled: @scoring_enabled,
-      live_score: @live_score,
       user: @user,
       visitor: @visitor
     %>

--- a/lib/dj_rumble_web/live/components/player_controls/player_controls.html.leex
+++ b/lib/dj_rumble_web/live/components/player_controls/player_controls.html.leex
@@ -6,6 +6,7 @@
       room_server: @room_server,
       scoring_enabled: @scoring_enabled,
       live_score: @live_score,
+      user: @user,
       visitor: @visitor
     %>
 

--- a/lib/dj_rumble_web/live/components/player_controls/score_panel/score_panel.ex
+++ b/lib/dj_rumble_web/live/components/player_controls/score_panel/score_panel.ex
@@ -13,6 +13,7 @@ defmodule DjRumbleWeb.Live.Components.PlayerControls.ScorePanel do
       live_score: live_score,
       room_server: room_server,
       scoring_enabled: scoring_enabled,
+      user: user,
       visitor: visitor
     } = assigns
 
@@ -21,15 +22,19 @@ defmodule DjRumbleWeb.Live.Components.PlayerControls.ScorePanel do
      |> assign(:id, id)
      |> assign(:live_score, live_score)
      |> assign(:scoring_enabled, scoring_enabled)
+     |> assign(:user, user)
      |> assign(:visitor, visitor)
      |> assign(:room_server, room_server)}
   end
 
-  def handle_event("score", %{"score" => type}, socket) do
-    %{room_server: room_server} = socket.assigns
+  def handle_event("score", _params, %{assigns: %{visitor: true}} = socket),
+    do: {:noreply, socket}
+
+  def handle_event("score", %{"score" => type}, %{assigns: %{visitor: false}} = socket) do
+    %{room_server: room_server, user: user} = socket.assigns
     type = String.to_atom(type)
 
-    :ok = RoomServer.score(room_server, self(), type)
+    :ok = RoomServer.score(room_server, user, type)
 
     scoring_enabled = %{positive: false, negative: false}
 

--- a/lib/dj_rumble_web/live/components/player_controls/score_panel/score_panel.ex
+++ b/lib/dj_rumble_web/live/components/player_controls/score_panel/score_panel.ex
@@ -21,10 +21,10 @@ defmodule DjRumbleWeb.Live.Components.PlayerControls.ScorePanel do
      socket
      |> assign(:id, id)
      |> assign(:live_score, live_score)
+     |> assign(:room_server, room_server)
      |> assign(:scoring_enabled, scoring_enabled)
      |> assign(:user, user)
-     |> assign(:visitor, visitor)
-     |> assign(:room_server, room_server)}
+     |> assign(:visitor, visitor)}
   end
 
   def handle_event("score", _params, %{assigns: %{visitor: true}} = socket),
@@ -36,13 +36,7 @@ defmodule DjRumbleWeb.Live.Components.PlayerControls.ScorePanel do
 
     :ok = RoomServer.score(room_server, user, type)
 
-    scoring_enabled = %{positive: false, negative: false}
-
-    send(self(), {:update_scoring_enabled, scoring_enabled})
-
-    {:noreply,
-     socket
-     |> assign(:scoring_enabled, scoring_enabled)}
+    {:noreply, socket}
   end
 
   defp render_score_button(type, is_scoring_enabled, visitor, assigns) do

--- a/lib/dj_rumble_web/live/room_live/show.html.leex
+++ b/lib/dj_rumble_web/live/room_live/show.html.leex
@@ -72,6 +72,7 @@
                 room_server: @room_server,
                 scoring_enabled: @scoring_enabled,
                 live_score: @live_score,
+                user: @user,
                 visitor: @visitor
               %>
             </div>

--- a/test/dj_rumble/room/room_server_test.exs
+++ b/test/dj_rumble/room/room_server_test.exs
@@ -563,7 +563,6 @@ defmodule DjRumble.Room.RoomServerTest do
       end)
     end
 
-    @tag :wip
     test "handle_call/3 :: {:joined, pid} is called some times, no rounds are started and some players receive playback details",
          %{
            state: state
@@ -649,7 +648,7 @@ defmodule DjRumble.Room.RoomServerTest do
       end)
     end
 
-    test "handle_cast/2 :: {:score, PID, :positive} is called once time and returns :ok", %{
+    test "handle_call/3 :: {:score, %User{}, :positive} is called once time and returns :ok", %{
       state: state
     } do
       # Setup
@@ -697,7 +696,7 @@ defmodule DjRumble.Room.RoomServerTest do
       _state = handle_scores(state, users_scores)
     end
 
-    test "handle_cast/2 :: {:score, PID, :negative} is called once time and returns :ok", %{
+    test "handle_call/3 :: {:score, %User{}, :negative} is called once time and returns :ok", %{
       state: state
     } do
       # Setup
@@ -721,7 +720,7 @@ defmodule DjRumble.Room.RoomServerTest do
       _state = handle_scores(state, users_scores)
     end
 
-    test "handle_cast/2 :: {:score, PID, :negative} is called many times and returns :ok every time",
+    test "handle_call/3 :: {:score, %User{}, :negative} is called many times and returns :ok every time",
          %{state: state} do
       # Setup
       %{matchmaking_server: matchmaking_server} = state
@@ -744,7 +743,7 @@ defmodule DjRumble.Room.RoomServerTest do
       _state = handle_scores(state, users_scores)
     end
 
-    test "handle_cast/2 :: {:score, PID, type} is called many times with mixed scores and returns :ok every time",
+    test "handle_call/3 :: {:score, %User{}, type} is called many times with mixed scores and returns :ok every time",
          %{state: state} do
       # Setup
       %{matchmaking_server: matchmaking_server} = state

--- a/test/dj_rumble/room/room_server_test.exs
+++ b/test/dj_rumble/room/room_server_test.exs
@@ -336,8 +336,8 @@ defmodule DjRumble.Room.RoomServerTest do
       videos_users = get_videos_users(state.room)
       time = 30
       :ok = schedule_and_start_round(matchmaking_server, videos_users, time)
-      players = spawn_players(1)
-      users_scores = generate_score(:positive, players)
+      [{_pid, user}] = spawn_players(1)
+      users_scores = generate_score(:positive, [user])
 
       # Exercise
       :ok = do_scores(pid, users_scores)
@@ -353,7 +353,8 @@ defmodule DjRumble.Room.RoomServerTest do
       time = 30
       :ok = schedule_and_start_round(matchmaking_server, videos_users, time)
       players = spawn_players(5)
-      users_scores = generate_score(:positive, players)
+      users = Enum.map(players, fn {_pid, user} -> user end)
+      users_scores = generate_score(:positive, users)
 
       # Exercise
       :ok = do_scores(pid, users_scores)

--- a/test/dj_rumble/round/round_server_test.exs
+++ b/test/dj_rumble/round/round_server_test.exs
@@ -448,6 +448,50 @@ defmodule DjRumble.Round.RoundServerTest do
       %{room_slug: ^slug, round: %Round.InProgress{score: ^evaluated_score}} = state
     end
 
+    test "handle_call/3 :: {:score, %User{}, type} is called many times by the same user with positive scores replies with a round with a score",
+         %{room: room, state: state} do
+      # Setup
+      %{slug: slug} = room
+
+      state =
+        state
+        |> handle_set_round_time(2)
+        |> handle_start_round()
+
+      user = user_fixture()
+      users = for _n <- 0..2, do: user
+      users_scores = generate_score(:positive, users)
+      scores = Enum.map(users_scores, fn {_user, score} -> score end)
+
+      # Exercise
+      {^scores, state} = handle_scores(state, users_scores)
+
+      # Verify
+      %{room_slug: ^slug, round: %Round.InProgress{score: {1, 0}}} = state
+    end
+
+    test "handle_call/3 :: {:score, %User{}, type} is called many times by the same user with negative scores replies with a round with a score",
+         %{room: room, state: state} do
+      # Setup
+      %{slug: slug} = room
+
+      state =
+        state
+        |> handle_set_round_time(2)
+        |> handle_start_round()
+
+      user = user_fixture()
+      users = for _n <- 0..2, do: user
+      users_scores = generate_score(:negative, users)
+      scores = Enum.map(users_scores, fn {_user, score} -> score end)
+
+      # Exercise
+      {^scores, state} = handle_scores(state, users_scores)
+
+      # Verify
+      %{room_slug: ^slug, round: %Round.InProgress{score: {0, 1}}} = state
+    end
+
     test "handle_info/2 :: :tick is called with a round that is in progress and does not reply",
          %{room: room, state: state} do
       %{slug: slug} = room

--- a/test/dj_rumble/round/round_server_test.exs
+++ b/test/dj_rumble/round/round_server_test.exs
@@ -15,9 +15,14 @@ defmodule DjRumble.Round.RoundServerTest do
   describe "round_server client interface" do
     setup do
       room = room_fixture()
-      round_time = 2
-      round_genserver_pid = start_supervised!({RoundServer, {room.slug, round_time}})
-      %{room: room, round_time: round_time, pid: round_genserver_pid}
+      round_genserver_pid = start_supervised!({RoundServer, {room.slug}})
+      %{room: room, pid: round_genserver_pid}
+    end
+
+    defp tick(pid, times) do
+      for _ <- 1..times do
+        :ok = Process.send(pid, :tick, [])
+      end
     end
 
     test "start_link/1 starts a round server", %{pid: pid} do
@@ -35,22 +40,21 @@ defmodule DjRumble.Round.RoundServerTest do
 
     test "start_round/1 ticks until the round pid terminates", %{pid: pid} do
       :ok = RoundServer.start_round(pid)
-      :ok = Process.sleep(3500)
-      refute Process.alive?(pid)
+      assert Process.alive?(pid)
     end
 
-    test "get_round/1 returns a scheduled round", %{pid: pid, round_time: round_time} do
-      %Round.Scheduled{time: ^round_time, elapsed_time: elapsed_time, score: score} =
+    test "get_round/1 returns a scheduled round", %{pid: pid} do
+      %Round.Scheduled{time: 0, elapsed_time: elapsed_time, score: score} =
         RoundServer.get_round(pid)
 
       assert elapsed_time == 0
       assert score == {0, 0}
     end
 
-    test "get_round/1 returns a round that is in progress", %{pid: pid, round_time: round_time} do
+    test "get_round/1 returns a round that is in progress", %{pid: pid} do
       :ok = RoundServer.start_round(pid)
 
-      %Round.InProgress{time: ^round_time, elapsed_time: elapsed_time, score: score, log: log} =
+      %Round.InProgress{time: 0, elapsed_time: elapsed_time, score: score, log: log} =
         RoundServer.get_round(pid)
 
       assert elapsed_time == 0
@@ -93,14 +97,34 @@ defmodule DjRumble.Round.RoundServerTest do
       %Round.InProgress{score: {0, 1}} = round
     end
 
-    test "handle_info/2 :tick updates a round that is in progress", %{
-      pid: pid,
-      round_time: round_time
-    } do
+    test "handle_info/2 :tick updates a round that is in progress", %{pid: pid} do
       :ok = RoundServer.start_round(pid)
-      :ok = Process.send(pid, :tick, [])
-      %Round.InProgress{time: ^round_time, elapsed_time: 1, log: log} = RoundServer.get_round(pid)
-      assert log == Log.new()
+      ticks = length(tick(pid, 1))
+      log = Log.new()
+      %Round.InProgress{time: 0, elapsed_time: ^ticks, log: ^log} = RoundServer.get_round(pid)
+    end
+
+    test "handle_info/2 :tick updates many times a round that is in progress", %{pid: pid} do
+      :ok = RoundServer.start_round(pid)
+      ticks = length(tick(pid, 10))
+      log = Log.new()
+      %Round.InProgress{time: 0, elapsed_time: ^ticks, log: ^log} = RoundServer.get_round(pid)
+    end
+
+    test "handle_info/2 :tick updates many times a round that is in progress until it finishes",
+         %{pid: pid} do
+      # Setup
+      :ok = RoundServer.set_round_time(pid, 10)
+      :ok = RoundServer.start_round(pid)
+
+      # Exercise
+      _ticks = tick(pid, 10)
+
+      # Verify
+      # We sleep for a few miliseconds to wait for the server to shutdown the
+      # round properly
+      :ok = Process.sleep(30)
+      refute Process.alive?(pid)
     end
   end
 
@@ -108,7 +132,7 @@ defmodule DjRumble.Round.RoundServerTest do
     setup do
       room = room_fixture(%{}, %{preload: true})
 
-      state = {room.slug, Round.schedule(0)}
+      state = RoundServer.initial_state(%{room_slug: room.slug, round: Round.schedule(0)})
 
       %{room: room, state: state}
     end
@@ -116,7 +140,7 @@ defmodule DjRumble.Round.RoundServerTest do
     defp handle_start_round(state) do
       response = RoundServer.handle_call(:start_round, nil, state)
 
-      {:reply, :ok, {_slug, %Round.InProgress{}} = state} = response
+      {:reply, :ok, %{round: %Round.InProgress{}} = state} = response
 
       state
     end
@@ -158,7 +182,7 @@ defmodule DjRumble.Round.RoundServerTest do
     defp handle_score(state, type) do
       response = RoundServer.handle_call({:score, type}, nil, state)
 
-      {:reply, new_round, {_slug, round} = state} = response
+      {:reply, new_round, %{round: round} = state} = response
 
       assert new_round == round
 
@@ -189,8 +213,8 @@ defmodule DjRumble.Round.RoundServerTest do
       end)
     end
 
-    defp get_round(state) do
-      elem(state, 1)
+    defp get_round(%{round: round}) do
+      round
     end
 
     test "handle_call/3 :: :start_round is called and replies :ok", %{state: state} do
@@ -244,7 +268,7 @@ defmodule DjRumble.Round.RoundServerTest do
         |> handle_set_round_time(2)
         |> handle_start_round()
         |> handle_tick(fn response ->
-          {:noreply, {^slug, %Round.InProgress{}} = state} = response
+          {:noreply, %{room_slug: ^slug, round: %Round.InProgress{}} = state} = response
           state
         end)
 
@@ -269,11 +293,13 @@ defmodule DjRumble.Round.RoundServerTest do
         |> handle_set_round_time(2)
         |> handle_start_round()
         |> handle_tick(fn response ->
-          {:noreply, {^slug, %Round.InProgress{}} = state} = response
+          {:noreply, %{room_slug: ^slug, round: %Round.InProgress{}} = state} = response
           state
         end)
         |> handle_tick(fn response ->
-          {:stop, {:shutdown, %Round.Finished{}}, {^slug, %Round.Finished{}} = state} = response
+          {:stop, {:shutdown, %Round.Finished{}},
+           %{room_slug: ^slug, round: %Round.Finished{}} = state} = response
+
           state
         end)
 
@@ -296,7 +322,8 @@ defmodule DjRumble.Round.RoundServerTest do
       %{slug: slug} = room
       time = 140
 
-      {^slug, %Round.Scheduled{time: ^time}} = handle_set_round_time(state, time)
+      %{room_slug: ^slug, round: %Round.Scheduled{time: ^time}} =
+        handle_set_round_time(state, time)
     end
 
     test "handle_call/3 :: {:score, :positive} is called once and replies with a round with a positive score",
@@ -309,14 +336,14 @@ defmodule DjRumble.Round.RoundServerTest do
         |> handle_set_round_time(2)
         |> handle_start_round()
 
-      {^slug, %Round.InProgress{score: initial_score}} = state
+      %{room_slug: ^slug, round: %Round.InProgress{score: initial_score}} = state
       scores = generate_score(:positive, 1)
       evaluated_score = get_evaluated_score(scores, initial_score)
       # Exercise
       {^scores, state} = handle_scores(state, scores)
 
       # Verify
-      {^slug, %Round.InProgress{score: ^evaluated_score}} = state
+      %{room_slug: ^slug, round: %Round.InProgress{score: ^evaluated_score}} = state
     end
 
     test "handle_call/3 :: {:score, :positive} is called many times and replies with a round with a positive score",
@@ -329,14 +356,14 @@ defmodule DjRumble.Round.RoundServerTest do
         |> handle_set_round_time(2)
         |> handle_start_round()
 
-      {^slug, %Round.InProgress{score: initial_score}} = state
+      %{room_slug: ^slug, round: %Round.InProgress{score: initial_score}} = state
       scores = generate_score(:positive, 3)
       evaluated_score = get_evaluated_score(scores, initial_score)
       # Exercise
       {^scores, state} = handle_scores(state, scores)
 
       # Verify
-      {^slug, %Round.InProgress{score: ^evaluated_score}} = state
+      %{room_slug: ^slug, round: %Round.InProgress{score: ^evaluated_score}} = state
     end
 
     test "handle_call/3 :: {:score, :negative} is called once and replies with a round with a negative score",
@@ -349,14 +376,14 @@ defmodule DjRumble.Round.RoundServerTest do
         |> handle_set_round_time(2)
         |> handle_start_round()
 
-      {^slug, %Round.InProgress{score: initial_score}} = state
+      %{room_slug: ^slug, round: %Round.InProgress{score: initial_score}} = state
       scores = generate_score(:negative, 1)
       evaluated_score = get_evaluated_score(scores, initial_score)
       # Exercise
       {^scores, state} = handle_scores(state, scores)
 
       # Verify
-      {^slug, %Round.InProgress{score: ^evaluated_score}} = state
+      %{room_slug: ^slug, round: %Round.InProgress{score: ^evaluated_score}} = state
     end
 
     test "handle_call/3 :: {:score, :negative} is called many times and replies with a round with a negative score",
@@ -369,14 +396,14 @@ defmodule DjRumble.Round.RoundServerTest do
         |> handle_set_round_time(2)
         |> handle_start_round()
 
-      {^slug, %Round.InProgress{score: initial_score}} = state
+      %{room_slug: ^slug, round: %Round.InProgress{score: initial_score}} = state
       scores = generate_score(:negative, 3)
       evaluated_score = get_evaluated_score(scores, initial_score)
       # Exercise
       {^scores, state} = handle_scores(state, scores)
 
       # Verify
-      {^slug, %Round.InProgress{score: ^evaluated_score}} = state
+      %{room_slug: ^slug, round: %Round.InProgress{score: ^evaluated_score}} = state
     end
 
     test "handle_call/3 :: {:score, type} is called many times with mixed scores replies with a round with a score",
@@ -389,27 +416,27 @@ defmodule DjRumble.Round.RoundServerTest do
         |> handle_set_round_time(2)
         |> handle_start_round()
 
-      {^slug, %Round.InProgress{score: initial_score}} = state
+      %{room_slug: ^slug, round: %Round.InProgress{score: initial_score}} = state
       scores = generate_score(:mixed, 10)
       evaluated_score = get_evaluated_score(scores, initial_score)
       # Exercise
       {^scores, state} = handle_scores(state, scores)
 
       # Verify
-      {^slug, %Round.InProgress{score: ^evaluated_score}} = state
+      %{room_slug: ^slug, round: %Round.InProgress{score: ^evaluated_score}} = state
     end
 
     test "handle_info/2 :: :tick is called with a round that is in progress and does not reply",
          %{room: room, state: state} do
       %{slug: slug} = room
 
-      _state =
+      :ok =
         state
         |> handle_set_round_time(2)
         |> handle_start_round()
         |> handle_tick(fn response ->
-          {:noreply, {^slug, %Round.InProgress{}} = state} = response
-          state
+          {:noreply, %{room_slug: ^slug, round: %Round.InProgress{}}} = response
+          :ok
         end)
     end
 
@@ -419,14 +446,14 @@ defmodule DjRumble.Round.RoundServerTest do
 
       :ok = Channels.subscribe(:room, slug)
 
-      _state =
+      :ok =
         state
         |> handle_set_round_time(2)
         |> handle_start_round()
         |> handle_score(:negative)
         |> handle_tick(fn response ->
-          {:noreply, {^slug, %Round.InProgress{}} = state} = response
-          state
+          {:noreply, %{room_slug: ^slug, round: %Round.InProgress{}}} = response
+          :ok
         end)
 
       assert_receive {:outcome_changed, %{round: %Round.InProgress{outcome: :thrown}}}
@@ -438,13 +465,15 @@ defmodule DjRumble.Round.RoundServerTest do
     } do
       %{slug: slug} = room
 
-      _state =
+      :ok =
         state
         |> handle_set_round_time(1)
         |> handle_start_round()
         |> handle_tick(fn response ->
-          {:stop, {:shutdown, %Round.Finished{}}, {^slug, %Round.Finished{}} = state} = response
-          state
+          {:stop, {:shutdown, %Round.Finished{}}, %{room_slug: ^slug, round: %Round.Finished{}}} =
+            response
+
+          :ok
         end)
     end
   end

--- a/test/dj_rumble/round/round_server_test.exs
+++ b/test/dj_rumble/round/round_server_test.exs
@@ -5,6 +5,7 @@ defmodule DjRumble.Round.RoundServerTest do
   use DjRumble.DataCase
   use ExUnit.Case
 
+  import DjRumble.AccountsFixtures
   import DjRumble.RoomsFixtures
 
   alias DjRumble.Rounds.{Log, Round, RoundServer}
@@ -71,9 +72,10 @@ defmodule DjRumble.Round.RoundServerTest do
     test "score/2 returns a round with a positive score", %{pid: pid} do
       # Setup
       :ok = RoundServer.start_round(pid)
+      user = user_fixture()
 
       # Exercise
-      round = RoundServer.score(pid, :positive)
+      round = RoundServer.score(pid, user, :positive)
 
       # Verify
       %Round.InProgress{score: {1, 0}} = round
@@ -82,9 +84,10 @@ defmodule DjRumble.Round.RoundServerTest do
     test "score/2 returns a round with a negative score", %{pid: pid} do
       # Setup
       :ok = RoundServer.start_round(pid)
+      user = user_fixture()
 
       # Exercise
-      round = RoundServer.score(pid, :negative)
+      round = RoundServer.score(pid, user, :negative)
 
       # Verify
       %Round.InProgress{score: {0, 1}} = round

--- a/test/dj_rumble/round/round_supervisor_test.exs
+++ b/test/dj_rumble/round/round_supervisor_test.exs
@@ -14,8 +14,7 @@ defmodule DjRumble.Round.RoundSupervisorTest do
 
     setup do
       room = room_fixture(%{}, %{preload: true})
-      round_time = 5
-      {:ok, pid} = RoundSupervisor.start_round_server(RoundSupervisor, {room.slug, round_time})
+      {:ok, pid} = RoundSupervisor.start_round_server(RoundSupervisor, {room.slug})
 
       on_exit(fn ->
         RoundSupervisor.terminate_round_server(RoundSupervisor, pid)


### PR DESCRIPTION
Este PR provee:

+ Refactor en los servicios de `RoomServer`, `Matchmaking` y `RoundServer` para manejar pedidos de ***scoring*** de usuarixs a través de mensajes hacia `Show` liveview.
+ Implementación de envio y recepción de mensajes de permisos de ***scoring*** en `RoundServer`
+ Actualización y agregado de tests